### PR TITLE
Fix GitHub Capitalization

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -69,7 +69,7 @@
             </a>
             <a class="button bg-gray-darker md:col-span-2" href="https://github.com/geode-sdk/geode">
                 <i data-feather="github"></i>
-                Github
+                GitHub
             </a>
         </div>
     </header>


### PR DESCRIPTION
Incase you couldn't tell what I mean, here's an attachment for it.
![librewolf_FYNu0ii25x](https://github.com/geode-sdk/website/assets/68702247/af85c3a8-52ce-472d-b82c-9c0ad20b96cf)
