### PR TITLE
Fix "Why can't I find a certain Mod?" button

### DIFF
--- a/src/routes/install/+page.svelte
+++ b/src/routes/install/+page.svelte
@@ -220,7 +220,7 @@
             You can use the <em>search button</em> on the left to search for specific mods by name or by <em>tags</em>.
         </p>
         <Row wrap="wrap">
-            <Button style="hollow">
+            <Button style="hollow" href="/faq#why-cant-i-find-certain-mods">
                 <Icon icon="help"/> Why can't I find a certain Mod?
             </Button>
         </Row>


### PR DESCRIPTION
added href to "Why can't I find a certain Mod?" button on download page.