### PR TITLE
feat(mods): better developers display on mod cards

### DIFF
--- a/src/lib/components/ModCard.svelte
+++ b/src/lib/components/ModCard.svelte
@@ -10,6 +10,7 @@
 
     import Label from "./Label.svelte";
     import ModLogo from "./ModLogo.svelte";
+    import ModDevelopersList from "./ModDevelopersList.svelte";
 
     export let mod: ServerMod;
     export let version: ServerModVersion;
@@ -18,7 +19,6 @@
     // add the version for non-accepted mods, as otherwise the endpoint will pick the latest accepted
     $: mod_url = version.status != "accepted" ? `/mods/${mod.id}?version=${version.version}` : `/mods/${mod.id}`;
 
-    $: owner = mod.developers.filter((d) => d.is_owner)[0];
     $: paid = mod.tags.includes("paid");
 </script>
 
@@ -49,9 +49,7 @@
                         </div>
                     </Link>
                 </div>
-                <Link href={`/mods?developer=${owner.username}`} --link-color="var(--accent-300)">
-                    {owner.display_name}
-                </Link>
+                <ModDevelopersList developers={mod.developers} full={false} />
                 <p class="description" title={version.description || ""}>
                     {#if version.description}
                         {#if version.description?.length < 110}
@@ -101,9 +99,7 @@
                 </Link>
             </Column>
         </span>
-        <Link href={`/mods?developer=${owner.username}`} --link-color="var(--accent-300)">
-            {owner.display_name}
-        </Link>
+        <ModDevelopersList developers={mod.developers} full={false} />
         <Gap size="small" />
         <Row>
             <span class="card-info">

--- a/src/lib/components/ModDeveloperLink.svelte
+++ b/src/lib/components/ModDeveloperLink.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+    import type { ServerModDeveloper } from "$lib/api/models/mod-developer";
+    import Link from "./Link.svelte";
+
+    export let developer: ServerModDeveloper;
+</script>
+
+<Link href={`/mods?developer=${developer.username}`} --link-color="var(--accent-300)">
+    {developer.display_name}
+</Link>

--- a/src/lib/components/ModDevelopersList.svelte
+++ b/src/lib/components/ModDevelopersList.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+    import type { ServerModDeveloper } from "$lib/api/models/mod-developer";
+    import Link from "./Link.svelte";
+    import ModDeveloperLink from "./ModDeveloperLink.svelte";
+
+    export let developers: ServerModDeveloper[];
+    export let full: boolean;
+</script>
+
+{#if full}
+    {#each developers as developer, index (developer.id)}
+        <span class="more">{index > 0 ? ", " : ""}</span><ModDeveloperLink developer={developer} />
+    {/each}
+{:else}
+    {#if developers.length === 0}
+        <span>Unknown</span>
+    {:else if developers.length === 1}
+        <ModDeveloperLink developer={developers[0]} />
+    {:else if developers.length === 2}
+        <span>
+            <ModDeveloperLink developer={developers[0]} />
+            <span class="more">&</span>
+            <ModDeveloperLink developer={developers[1]} />
+        </span>
+    {:else}
+        {@const owner = developers.find((d) => d.is_owner) ?? developers[0]}
+        <span>
+            <ModDeveloperLink developer={owner} />
+            <span class="more">
+                {`+ ${developers.length - 1} More`}
+            </span>
+        </span>
+    {/if}
+{/if}
+
+<style lang="scss">
+.more {
+    font-size: 0.9em;
+    color: var(--text-300);
+}
+</style>

--- a/src/routes/mods/[id]/+page.svelte
+++ b/src/routes/mods/[id]/+page.svelte
@@ -26,6 +26,7 @@
     import type { ModStatus } from "$lib/api/models/mod-version.js";
     import GeodeMarkdown from "$lib/components/GeodeMarkdown.svelte";
     import ModLogo from "$lib/components/ModLogo.svelte";
+    import ModDevelopersList from "$lib/components/ModDevelopersList.svelte";
 
     export let data: PageData;
 
@@ -121,11 +122,7 @@
             </h1>
         </div>
         <p>
-            {#each data.mod.developers as dev, index}
-                {index > 0 ? ", " : ""}<Link href={`/mods?developer=${dev.username}`} --link-color="var(--accent-300)">
-                    {dev.display_name}
-                </Link>
-            {/each}
+            <ModDevelopersList developers={data.mod.developers} full={true} />
         </p>
     </Column>
 </header>


### PR DESCRIPTION
This PR modifies how developers are displayed on Mod Cards so that it matches how Geode's mod UI shows developers on its Mod Items.

Geode mod:
![image](https://github.com/user-attachments/assets/b2800c70-9372-4aa4-9c62-fb8b7999a74d)

Before PR:
![image](https://github.com/user-attachments/assets/2a973dad-4e8a-43bb-9a17-2da16d3c02db)

After PR:
![image](https://github.com/user-attachments/assets/6aba9878-6800-4114-8819-ad729b6d1552)

The algorithm in the mod is located at https://github.com/geode-sdk/geode/blob/0b71c3c8b1c3f0afbb307d34e1bb7effb8945c8c/loader/src/server/Server.cpp#L496.