### PR TITLE
Add GDPS mod tag icon

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -83,6 +83,7 @@ export const icons = {
     "tag-customization": "mdi:paint-outline",
     "tag-content": "mdi:auto-stories",
     "tag-developer": "mdi:code-braces",
+    "tag-gdps": "mdi:server",
     "tag-cheat": "mdi:domino-mask",
     "tag-paid": "mdi:attach-money",
     "tag-joke": "mdi:comedy",


### PR DESCRIPTION
Linked to these other pull requests:
- [geode-sdk/geode](https://github.com/geode-sdk/geode/pull/2108)
- [geode-sdk/server](https://github.com/geode-sdk/server/pull/72)
- [geode-sdk/docs](https://github.com/geode-sdk/docs/pull/115)

Adds the GDPS mod tag to the website